### PR TITLE
Add request_id propagation and enhanced logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
 # devin-demo-service
+
+A demo FastAPI service with structured JSON logging and request_id propagation.
+
+## Features
+
+- **Structured JSON Logging**: All logs are output in JSON format for easy parsing
+- **Request ID Propagation**: Each request gets a unique request_id that appears in all related log entries
+- **Configurable Log Level**: Set log level via `LOG_LEVEL` environment variable
+
+## Request ID Propagation
+
+The service automatically generates a unique `request_id` (UUID4) for each incoming HTTP request. If the client sends an `X-Request-ID` header, that value is used instead, enabling request tracing across multiple services.
+
+The `request_id` is:
+- Included in all log entries during request processing
+- Returned in the response via the `X-Request-ID` header
+
+## Configuration
+
+### Log Level
+
+Set the log level using the `LOG_LEVEL` environment variable:
+
+```bash
+export LOG_LEVEL=DEBUG
+# Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
+# Default: INFO
+```
+
+## Log Format
+
+Logs are output as JSON with the following structure:
+
+```json
+{
+  "timestamp": "2024-10-04T00:12:15.123456Z",
+  "level": "INFO",
+  "message": "Log message here",
+  "logger": "app.main",
+  "request_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+## Filtering Logs with jq
+
+Use `jq` to filter and analyze logs by request_id:
+
+### Filter logs by specific request_id
+```bash
+cat logs.json | jq 'select(.request_id == "550e8400-e29b-41d4-a716-446655440000")'
+```
+
+### Show only messages for a specific request_id
+```bash
+cat logs.json | jq -r 'select(.request_id == "550e8400-e29b-41d4-a716-446655440000") | .message'
+```
+
+### Group and count logs by request_id
+```bash
+cat logs.json | jq -r '.request_id' | sort | uniq -c | sort -rn
+```
+
+### Show logs for a specific request_id with timestamp and level
+```bash
+cat logs.json | jq -r 'select(.request_id == "550e8400-e29b-41d4-a716-446655440000") | "\(.timestamp) [\(.level)] \(.message)"'
+```
+
+### Filter by request_id and log level
+```bash
+cat logs.json | jq 'select(.request_id == "550e8400-e29b-41d4-a716-446655440000" and .level == "ERROR")'
+```
+
+## Running the Service
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,17 @@
+import uuid
 from fastapi import FastAPI
-from .logging_config import get_logger
+from .logging_config import get_logger, request_id_var
 
 app = FastAPI(title="Devin Demo Service")
 log = get_logger(__name__)
+
+@app.middleware("http")
+async def request_id_middleware(request, call_next):
+    request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+    request_id_var.set(request_id)
+    response = await call_next(request)
+    response.headers["X-Request-ID"] = request_id
+    return response
 
 @app.get("/health")
 def health():


### PR DESCRIPTION
# Add request_id propagation and enhanced logging configuration

## Summary
This PR implements request ID propagation across the FastAPI service and enhances the existing JSON logging configuration. Key changes include:

- **FastAPI middleware** that generates a unique UUID4 request_id for each request (or uses existing X-Request-ID header)
- **Enhanced JsonFormatter** to include request_id in all log entries using Python's contextvars for thread-safe async context
- **LOG_LEVEL environment variable** support for runtime log level configuration  
- **Comprehensive documentation** with jq filtering examples for log analysis

The request_id is automatically included in response headers as X-Request-ID to support distributed tracing.

## Review & Testing Checklist for Human
- [ ] **Test request_id propagation end-to-end**: Start the service and make HTTP requests - verify that request_id appears in JSON logs and response headers
- [ ] **Verify context isolation**: Make concurrent requests and confirm each gets a unique request_id in logs (no cross-contamination)
- [ ] **Test X-Request-ID header handling**: Send requests both with and without the X-Request-ID header to verify proper precedence
- [ ] **Validate LOG_LEVEL environment variable**: Test different log levels (DEBUG, INFO, WARNING, ERROR) via environment variable
- [ ] **Test error scenarios**: Trigger errors/exceptions and confirm request_id still appears in error logs

### Notes
- Uses Python's `contextvars` for thread-safe async context management - this should work correctly with FastAPI but needs verification
- Middleware execution order could matter if other middleware is added later
- No validation on incoming X-Request-ID headers (passes through whatever client sends)

Link to Devin run: https://app.devin.ai/sessions/500b85f5b2b94252b8440230833eaf88  
Requested by: @Saumya-Chauhan-MHC