### PR TITLE
Fix: /health endpoint always returns 200

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,4 +9,4 @@ def health():
     probe = {"status": "ok"}  # pretend this is flaky in staging
     if probe and probe.get("status") == "ok":
         return {"ok": True}
-    return {"ok": probe.get("status") == "ok"}  # will crash if probe=None (useful for a bug issue)
+    return {"ok": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_endpoint_returns_200():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+def test_health_endpoint_always_returns_ok():
+    for _ in range(10):
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}


### PR DESCRIPTION
# Fix: /health endpoint always returns 200

## Summary
Fixes intermittent 500 errors in the `/health` endpoint by removing the crash scenario when `probe=None`. The endpoint now consistently returns `200` with `{"ok": true}` as specified in the requirements.

**Changes:**
- Modified fallback return in `/health` endpoint to always return `{"ok": true}` instead of attempting to access `probe.get("status")` when probe is None
- Added basic test coverage with pytest to verify endpoint behavior
- Added `requirements.txt` for testing dependencies

## Review & Testing Checklist for Human
- [ ] **Verify business requirements**: Confirm that always returning success aligns with intended health check behavior (this removes the intentional crash scenario mentioned in the original comment)
- [ ] **Test in staging environment**: Deploy and verify that the intermittent 500 errors are actually resolved in the staging environment where the issue was observed
- [ ] **Consider probe logic**: Review whether any actual external dependency status checking should be preserved vs. always returning healthy

### Notes
- The original code included a comment that the crash was "useful for a bug issue" - this PR removes that intentional failure behavior entirely
- Local tests pass but only verify the happy path; staging testing is critical since that's where the issue was observed
- This PR was created by Devin AI assisting @Saumya-Chauhan-MHC

**Link to Devin run:** https://app.devin.ai/sessions/b62ae23af4d844eca693cc81544f9419