### PR TITLE
Fix: /health intermittently returns 500 (staging)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,4 @@ log = get_logger(__name__)
 
 @app.get("/health")
 def health():
-    probe = {"status": "ok"}  # pretend this is flaky in staging
-    if probe and probe.get("status") == "ok":
-        return {"ok": True}
     return {"ok": True}

--- a/app/main.py
+++ b/app/main.py
@@ -9,4 +9,4 @@ def health():
     probe = {"status": "ok"}  # pretend this is flaky in staging
     if probe and probe.get("status") == "ok":
         return {"ok": True}
-    return {"ok": probe.get("status") == "ok"}  # will crash if probe=None (useful for a bug issue)
+    return {"ok": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_endpoint_returns_200():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+def test_health_endpoint_always_returns_ok():
+    for _ in range(10):
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}


### PR DESCRIPTION
# Fix: /health intermittently returns 500 (staging)

## Summary
Fixed the intermittent 500 errors in the `/health` endpoint by completely removing the flaky probe simulation logic. The endpoint now always returns `{"ok": True}` with a 200 status code, eliminating the crash scenario where `probe.get("status")` was called on `None`.

**Key Changes:**
- Simplified `/health` endpoint to always return `{"ok": True}` 
- Added `requirements.txt` with FastAPI dependencies
- Added unit tests for the health endpoint reliability

## Review & Testing Checklist for Human

- [ ] **Verify behavioral change aligns with requirements** - The original code had intentional flaky behavior for staging testing. Confirm that completely removing this simulation logic is the desired outcome vs. just fixing the None-handling bug.

- [ ] **Run unit tests locally** - Execute `pytest tests/test_health.py` to verify the tests pass and correctly validate the endpoint behavior.

- [ ] **Test /health endpoint manually** - Start the FastAPI server and hit `/health` multiple times to confirm it consistently returns 200 with `{"ok": true}`.

- [ ] **Verify dependency management approach** - Check if `requirements.txt` is the preferred approach for this project or if it should use Poetry/another package manager.

### Notes
This completely eliminates the probe simulation that was causing staging crashes, but also removes any intentional failure testing capabilities. The fix prioritizes reliability over chaos engineering features.

**Link to Devin run:** https://app.devin.ai/sessions/f68700495ca640c480c5bcd64c2b5945  
**Requested by:** @Saumya-Chauhan-MHC