### PR TITLE
Fix /health endpoint to always return 200

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,4 @@ log = get_logger(__name__)
 
 @app.get("/health")
 def health():
-    probe = {"status": "ok"}  # pretend this is flaky in staging
-    if probe and probe.get("status") == "ok":
-        return {"ok": True}
     return {"ok": True}

--- a/app/main.py
+++ b/app/main.py
@@ -9,4 +9,4 @@ def health():
     probe = {"status": "ok"}  # pretend this is flaky in staging
     if probe and probe.get("status") == "ok":
         return {"ok": True}
-    return {"ok": probe.get("status") == "ok"}  # will crash if probe=None (useful for a bug issue)
+    return {"ok": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pytest
+httpx

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_health_endpoint_returns_200():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+def test_health_endpoint_always_returns_ok():
+    for _ in range(10):
+        response = client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}


### PR DESCRIPTION
# Fix /health endpoint to always return 200

## Summary
Fixes intermittent 500 errors from the `/health` endpoint by removing the flaky probe logic that could crash when `probe=None`. The endpoint now consistently returns `{"ok": true}` with a 200 status code.

**Key Changes:**
- Simplified `health()` function to always return `{"ok": true}`
- Removed probe simulation logic that caused `AttributeError` when `probe=None`
- Added comprehensive tests and basic project dependencies

## Review & Testing Checklist for Human
- [ ] **Verify removing flaky behavior aligns with requirements** - Original code comments suggest the flaky behavior was intentional for testing ("pretend this is flaky in staging", "useful for a bug issue"). Confirm this complete removal is what's actually desired vs. just fixing the None case.
- [ ] **Test in staging environment** - Deploy and verify the endpoint consistently returns 200, and ensure this doesn't break any monitoring/alerting that expected occasional failures
- [ ] **Run the included tests** - Execute `python -m pytest tests/` to verify both test cases pass

### Notes
- This eliminates the `AttributeError: 'NoneType' object has no attribute 'get'` that occurred when probe was None
- The fix removes all probe logic rather than just handling the None case, which represents a behavioral change from sometimes-failing to always-succeeding
- Tests include both single-call and multiple-iteration reliability checks

*Link to Devin run: https://app.devin.ai/sessions/67baa4324a974aa1b037806be73d8207*
*Requested by: @Saumya-Chauhan-MHC*