### PR TITLE
Feature: Add Prometheus /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # devin-demo-service
+
+A minimal FastAPI service with Prometheus metrics support.
+
+## Features
+
+- `/health` - Health check endpoint
+- `/metrics` - Prometheus metrics endpoint
+
+## Metrics
+
+The service exports the following Prometheus metrics:
+
+- `request_count{method,path,status}` - Total number of HTTP requests
+- `request_latency_seconds{method,path}` - HTTP request latency histogram
+
+## Prometheus Configuration
+
+Add the following to your `prometheus.yml` to scrape metrics from this service:
+
+```yaml
+scrape_configs:
+  - job_name: 'devin-demo-service'
+    static_configs:
+      - targets: ['localhost:8000']
+    metrics_path: '/metrics'
+    scrape_interval: 15s
+```
+
+## Running the Service
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Running Tests
+
+```bash
+pytest
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,25 @@
-from fastapi import FastAPI
+import time
+from fastapi import FastAPI, Request, Response
 from .logging_config import get_logger
+from .metrics import render_metrics_text, get_content_type, request_count, request_latency_seconds
 
 app = FastAPI(title="Devin Demo Service")
 log = get_logger(__name__)
+
+@app.middleware("http")
+async def metrics_middleware(request: Request, call_next):
+    start_time = time.time()
+    response = await call_next(request)
+    duration = time.time() - start_time
+    
+    path = request.url.path
+    method = request.method
+    status = str(response.status_code)
+    
+    request_count.labels(method=method, path=path, status=status).inc()
+    request_latency_seconds.labels(method=method, path=path).observe(duration)
+    
+    return response
 
 @app.get("/health")
 def health():
@@ -10,3 +27,7 @@ def health():
     if probe and probe.get("status") == "ok":
         return {"ok": True}
     return {"ok": probe.get("status") == "ok"}  # will crash if probe=None (useful for a bug issue)
+
+@app.get("/metrics")
+def metrics():
+    return Response(content=render_metrics_text(), media_type=get_content_type())

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,8 +1,27 @@
-# TODO: implement Prometheus /metrics exporter
+from prometheus_client import Counter, Histogram, generate_latest, REGISTRY
+from prometheus_client.exposition import CONTENT_TYPE_LATEST
+
+request_count = Counter(
+    'request_count',
+    'Total HTTP requests',
+    ['method', 'path', 'status']
+)
+
+request_latency_seconds = Histogram(
+    'request_latency_seconds',
+    'HTTP request latency in seconds',
+    ['method', 'path'],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0)
+)
+
 def render_metrics_text() -> str:
     """
     Return Prometheus text-format metrics.
     Example:
       request_count{path="/health",method="GET",status="200"} 42
     """
-    raise NotImplementedError("Metrics exporter not implemented yet")
+    return generate_latest(REGISTRY).decode('utf-8')
+
+def get_content_type() -> str:
+    """Return the Prometheus metrics content type."""
+    return CONTENT_TYPE_LATEST

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+prometheus-client
+pytest
+httpx

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,49 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_metrics_endpoint_returns_200():
+    response = client.get("/metrics")
+    assert response.status_code == 200
+
+def test_metrics_content_type():
+    response = client.get("/metrics")
+    assert "text/plain" in response.headers["content-type"]
+
+def test_metrics_contains_request_count():
+    response = client.get("/metrics")
+    assert "request_count" in response.text
+
+def test_metrics_contains_latency_histogram():
+    response = client.get("/metrics")
+    assert "request_latency_seconds" in response.text
+
+def test_metrics_increment_after_request():
+    response_before = client.get("/metrics")
+    before_text = response_before.text
+    
+    client.get("/health")
+    
+    response_after = client.get("/metrics")
+    after_text = response_after.text
+    
+    assert "request_count" in after_text
+    assert "/health" in after_text
+
+def test_health_endpoint_still_works():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+def test_metrics_format():
+    response = client.get("/metrics")
+    lines = response.text.split('\n')
+    
+    metric_lines = [line for line in lines if line and not line.startswith('#')]
+    assert len(metric_lines) > 0
+    
+    for line in metric_lines:
+        if line.strip():
+            assert '{' in line or ' ' in line


### PR DESCRIPTION
# Feature: Add Prometheus /metrics endpoint

## Summary
Implements a Prometheus-compatible `/metrics` endpoint with HTTP request instrumentation. Adds middleware to track `request_count{method,path,status}` and `request_latency_seconds{method,path}` for all incoming requests. Includes comprehensive unit tests and documentation with Prometheus scraping configuration examples.

**Key changes:**
- New `/metrics` GET endpoint returning Prometheus text format
- HTTP middleware tracking request counts and latency histograms  
- Implemented `render_metrics_text()` function using `prometheus-client` library
- Added 7 unit tests covering endpoint functionality and metrics collection
- Updated README with Prometheus scraping configuration and usage instructions
- Added dependencies: `prometheus-client`, `pytest`, `httpx`

## Review & Testing Checklist for Human
**3 critical items to verify:**

- [ ] **Deploy and test `/metrics` endpoint in actual environment** - Verify the endpoint returns valid Prometheus format and Prometheus can successfully scrape it
- [ ] **Performance impact assessment** - Test service under normal load to ensure middleware doesn't introduce significant latency (baseline vs. with metrics)
- [ ] **Metrics accuracy validation** - Make several requests to `/health` and verify that `request_count` increments correctly and latency values are reasonable in `/metrics` output

### Notes
- All 7 unit tests pass locally, but integration testing in deployment environment is recommended
- Current implementation tracks metrics by exact path - consider impact if dynamic path parameters are added later
- Dependencies added without version pinning - may want to pin versions for production stability
- Histogram buckets are configured for typical web service latencies (5ms to 10s)

---
**Requested by:** @Saumya-Chauhan-MHC  
**Link to Devin run:** https://app.devin.ai/sessions/4e3241cbaa234682b2f07bc7ab4f0c59